### PR TITLE
Make cipher suites be represented as ubint8 instead of bytes.

### DIFF
--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -52,7 +52,7 @@ SessionID = Struct(
 CipherSuites = Struct(
     "cipher_suites",
     UBInt16("length"),  # TODO: Reject packets of length 0
-    Array(lambda ctx: ctx.length / 2, Bytes("cipher_suites", 2)),
+    Array(lambda ctx: ctx.length // 2, UBInt16("cipher_suites")),
 )
 
 CompressionMethods = Struct(

--- a/tls/test/test_hello_messages.py
+++ b/tls/test/test_hello_messages.py
@@ -58,7 +58,7 @@ class TestClientHello(object):
         assert record.random.gmt_unix_time == 16909060
         assert record.random.random_bytes == b'0123456789012345678901234567'
         assert record.session_id == b'01234567890123456789012345678901'
-        assert record.cipher_suites == [b'\x00\x6B']
+        assert record.cipher_suites == [107]
         assert record.compression_methods == [0]
         assert len(record.extensions) == 0
 

--- a/tls/test/test_hello_messages.py
+++ b/tls/test/test_hello_messages.py
@@ -58,7 +58,7 @@ class TestClientHello(object):
         assert record.random.gmt_unix_time == 16909060
         assert record.random.random_bytes == b'0123456789012345678901234567'
         assert record.session_id == b'01234567890123456789012345678901'
-        assert record.cipher_suites == [107]
+        assert record.cipher_suites == [0x006b]
         assert record.compression_methods == [0]
         assert len(record.extensions) == 0
 


### PR DESCRIPTION
The list of cipher suites is better represented as `UBInt16`. Fixes #37.