### PR TITLE
Cipher selection logic

### DIFF
--- a/tls/ciphersuites.py
+++ b/tls/ciphersuites.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function
 
 from enum import Enum
 
+from tls.exceptions import UnsupportedCipherException
+
 
 class CipherSuites(Enum):
     TLS_NULL_WITH_NULL_NULL = 0x0000
@@ -336,6 +338,6 @@ def select_preferred_ciphersuite(client_supported, server_supported):
         if i in client_supported:
             return i
     else:
-        raise ValueError(
+        raise UnsupportedCipherException(
             "Client supported ciphersuites are not supported on the server."
         )

--- a/tls/ciphersuites.py
+++ b/tls/ciphersuites.py
@@ -337,7 +337,7 @@ def select_preferred_ciphersuite(client_supported, server_supported):
         assert isinstance(i, CipherSuites)
         if i in client_supported:
             return i
-    else:
-        raise UnsupportedCipherException(
-            "Client supported ciphersuites are not supported on the server."
-        )
+
+    raise UnsupportedCipherException(
+        "Client supported ciphersuites are not supported on the server."
+    )

--- a/tls/ciphersuites.py
+++ b/tls/ciphersuites.py
@@ -328,3 +328,14 @@ class CipherSuites(Enum):
     TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 = 0xC0AF
     TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 = 0xCC14
     TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 = 0xCC13
+
+
+def select_preferred_ciphersuite(client_supported, server_supported):
+    for i in server_supported:
+        assert isinstance(i, CipherSuites)
+        if i in client_supported:
+            return i
+    else:
+        raise ValueError(
+            "Client supported ciphersuites are not supported on the server."
+        )

--- a/tls/exceptions.py
+++ b/tls/exceptions.py
@@ -1,0 +1,2 @@
+class UnsupportedCipherException(Exception):
+    pass

--- a/tls/test/test_ciphersuites.py
+++ b/tls/test/test_ciphersuites.py
@@ -2,10 +2,32 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
-from tls.ciphersuites import CipherSuites
+import pytest
+
+from tls.ciphersuites import CipherSuites, select_preferred_ciphersuite
+from tls.exceptions import UnsupportedCipherException
 
 
 def test_ciphersuites():
     # TODO: This is to fulfill test coverage. Either make more useful later or
     # remove once the CipherSuites enum gets used in other places.
     assert CipherSuites.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256.value == 0x006B
+
+
+def test_select_preferred_ciphersuite():
+    assert select_preferred_ciphersuite([
+        CipherSuites.TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA,
+        CipherSuites.TLS_DH_anon_EXPORT_WITH_RC4_40_MD5
+    ], [
+        CipherSuites.TLS_DH_anon_EXPORT_WITH_RC4_40_MD5,
+        CipherSuites.TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA
+    ]) == CipherSuites.TLS_DH_anon_EXPORT_WITH_RC4_40_MD5
+
+
+def test_unsupported_ciphersuite():
+    with pytest.raises(UnsupportedCipherException):
+        select_preferred_ciphersuite([
+            CipherSuites.TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA
+        ], [
+            CipherSuites.TLS_DH_anon_EXPORT_WITH_RC4_40_MD5
+        ])


### PR DESCRIPTION
Fixes #68.

This just implements the selection logic in an isolated function. I wished there was a way to assert that values in the `client_supported` and `server_supported` iterables are members of the CipherSuite enum without iterating over them.

