### PR TITLE
Fix pep8 errors about a newline before the '+' operator

### DIFF
--- a/tls/test/test_message.py
+++ b/tls/test/test_message.py
@@ -88,8 +88,7 @@ class TestPreMasterSecretParsing(object):
         import os
         r = os.urandom(46)
         packet = (
-            b'\x03\x00'  # ClientHello.client_version
-            + r
+            b'\x03\x00' + r  # ClientHello.client_version + random
         )
         record = PreMasterSecret.from_bytes(packet)
         assert isinstance(record, PreMasterSecret)


### PR DESCRIPTION
pep8 wasn't happy eith a new line before a binary operator. This should make it happy.