### PR TITLE
Use relative imports

### DIFF
--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from construct import Array, Bytes, Struct, UBInt16, UBInt32, UBInt8
 
-from tls.utils import UBInt24
+from .utils import UBInt24
 
 
 ProtocolVersion = Struct(

--- a/tls/alert_message.py
+++ b/tls/alert_message.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 from characteristic import attributes
 
-from tls import _constructs
+from . import _constructs
 
 
 class AlertLevel(Enum):

--- a/tls/ciphersuites.py
+++ b/tls/ciphersuites.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from enum import Enum
 
-from tls.exceptions import UnsupportedCipherException
+from .exceptions import UnsupportedCipherException
 
 
 class CipherSuites(Enum):

--- a/tls/hello_message.py
+++ b/tls/hello_message.py
@@ -12,7 +12,7 @@ from construct import Container
 
 from six import BytesIO
 
-from tls import _constructs
+from . import _constructs
 
 
 @attributes(['major', 'minor'])

--- a/tls/message.py
+++ b/tls/message.py
@@ -12,9 +12,9 @@ from construct import Container
 
 from six import BytesIO
 
-from tls import _constructs
+from . import _constructs
 
-from tls.hello_message import (
+from .hello_message import (
     ClientHello, ProtocolVersion, ServerHello
 )
 

--- a/tls/record.py
+++ b/tls/record.py
@@ -10,7 +10,7 @@ from characteristic import attributes
 
 from construct import Container
 
-from tls import _constructs
+from . import _constructs
 
 
 @attributes(['major', 'minor'])

--- a/tls/test/test_alert.py
+++ b/tls/test/test_alert.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from tls.alert_message import Alert, AlertDescription, AlertLevel
+from ..alert_message import Alert, AlertDescription, AlertLevel
 
 
 class TestAlert(object):

--- a/tls/test/test_ciphersuites.py
+++ b/tls/test/test_ciphersuites.py
@@ -4,8 +4,8 @@
 
 import pytest
 
-from tls.ciphersuites import CipherSuites, select_preferred_ciphersuite
-from tls.exceptions import UnsupportedCipherException
+from ..ciphersuites import CipherSuites, select_preferred_ciphersuite
+from ..exceptions import UnsupportedCipherException
 
 
 def test_ciphersuites():

--- a/tls/test/test_hello_messages.py
+++ b/tls/test/test_hello_messages.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from tls.hello_message import (
+from ..hello_message import (
     ClientHello, CompressionMethod, ExtensionType, ServerHello
 )
 

--- a/tls/test/test_message.py
+++ b/tls/test/test_message.py
@@ -4,9 +4,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-from tls.hello_message import ClientHello, ProtocolVersion, ServerHello
+from ..hello_message import ClientHello, ProtocolVersion, ServerHello
 
-from tls.message import (
+from ..message import (
     Certificate, CertificateRequest, ClientCertificateType, Finished,
     Handshake, HandshakeType, HashAlgorithm, HelloRequest, PreMasterSecret,
     ServerDHParams, ServerHelloDone, SignatureAlgorithm

--- a/tls/test/test_record.py
+++ b/tls/test/test_record.py
@@ -8,7 +8,7 @@ from construct.core import FieldError
 
 import pytest
 
-from tls.record import (
+from ..record import (
     ContentType, TLSCiphertext, TLSCompressed, TLSPlaintext
 )
 

--- a/tls/test/test_utils.py
+++ b/tls/test/test_utils.py
@@ -8,7 +8,7 @@ from construct.core import Construct
 
 import pytest
 
-from tls.utils import UBInt24, _UBInt24
+from ..utils import UBInt24, _UBInt24
 
 
 @pytest.mark.parametrize("byte,number", [


### PR DESCRIPTION
This PR replaces all absolute imports within the module with relative ones, as suggested by [PEP 0328](https://www.python.org/dev/peps/pep-0328/). The practical application is that I can embed `tls` in a `.contrib` module in mitmproxy, where we re-use the _construct bits. :smiley: