### PR TITLE
Add Extension Parsing

### DIFF
--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -112,7 +112,7 @@ Extension = Struct(
 )
 
 extensions = TunnelAdapter(
-    PascalString("extensions", length_field=UBInt16("extensions_length")),
+    Optional(PascalString("extensions", length_field=UBInt16("extensions_length"))),
     OptionalGreedyRange(Extension)
 )
 


### PR DESCRIPTION
We needed a way to parse ClientHello packets in mitmproxy to get around OpenSSL's API Limitations (see [here](https://github.com/mitmproxy/mitmproxy/blob/2cfc1b1b4030838f6047f18f8014c91926b414d0/libmproxy/protocol2/tls.py#L32-L44)), so why not build this on top of something existing... :smile: 

This PR improves the parsing of ClientHello messages - while it's probably not perfect, I think there are few valueable bits in here - for example, I found

``` python
extensions = TunnelAdapter(
    PascalString("extensions", length_field=UBInt16("extensions_length")),
    OptionalGreedyRange(Extension)
)
```

quite non-obivous from the construct docs. The ClientHello tests don't pass for this PR, as extension parsing was implemented in `hello_message` as well (see [here](https://github.com/pyca/tls/blob/f4614142bd62e23af23e476244f96db2e3684f16/tls/hello_message.py#L152)). As I don't know how the relation between `_construct` and `message`/`hello_message` is intended to be, I'll leave this here as-is for now.

Thanks for the great project!
