### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,6 +56,6 @@ Software License Version 2.0 licenses.
 
 
 .. _`PEP 8`: http://legacy.python.org/dev/peps/pep-0008/
-.. _`flake8`: https://flake8.readthedocs.org/en/2.1.0/
+.. _`flake8`: https://flake8.readthedocs.io/en/2.1.0/
 .. _`good commit messages`: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 .. _`squash`: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.