### PR TITLE
Remove Python 2.6 and 3.2 from tox.ini environments list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 
 matrix:
     include:
-        - env: TOXENV=py26
         - env: TOXENV=py27
-        - env: TOXENV=py32
         - env: TOXENV=py33
         - env: TOXENV=py34
         - env: TOXENV=pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,docs,pep8,py3pep8
+envlist = py27,py33,py34,pypy,docs,pep8,py3pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Coverage and pip no longer support Python 3.2 and Python 2.6 lacks
features that make cross compatibility easier.  tls should longer
support these versions.