### PR TITLE
Length validation

### DIFF
--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -4,10 +4,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
+
 from construct import Array, Bytes, Struct, UBInt16, UBInt32, UBInt8
 
 from tls.ciphersuites import CipherSuites
-from tls.utils import EnumClass, PrefixedBytes, TLSPrefixedArray, UBInt24
+from tls.utils import (EnumClass, PrefixedBytes, SizeAtLeast,
+                       SizeAtMost, SizeWithin, TLSPrefixedArray, UBInt24)
 
 
 ProtocolVersion = Struct(
@@ -20,24 +23,27 @@ TLSPlaintext = Struct(
     "TLSPlaintext",
     UBInt8("type"),
     ProtocolVersion,
-    # TODO: Reject packets with length > 2 ** 14
-    PrefixedBytes("fragment", UBInt16("length")),
+    PrefixedBytes("fragment",
+                  SizeAtMost(UBInt16("length"),
+                             max_size=2 ** 14)),
 )
 
 TLSCompressed = Struct(
     "TLSCompressed",
     UBInt8("type"),
     ProtocolVersion,
-    # TODO: Reject packets with length > 2 ** 14 + 1024
-    PrefixedBytes("fragment", UBInt16("length")),
+    PrefixedBytes("fragment",
+                  SizeAtMost(UBInt16("length"),
+                             max_size=2 ** 14 + 1024)),
 )
 
 TLSCiphertext = Struct(
     "TLSCiphertext",
     UBInt8("type"),
     ProtocolVersion,
-    # TODO: Reject packets with length > 2 ** 14 + 2048
-    PrefixedBytes("fragment", UBInt16("length")),
+    PrefixedBytes("fragment",
+                  SizeAtMost(UBInt16("length"),
+                             max_size=2 ** 14 + 2048)),
 )
 
 Random = Struct(
@@ -54,8 +60,8 @@ SessionID = Struct(
 
 CompressionMethods = Struct(
     "compression_methods",
-    UBInt8("length"),  # TODO: Reject packets of length 0
-    Array(lambda ctx: ctx.length, UBInt8("compression_methods")),
+    SizeAtLeast(UBInt8("length"), min_size=1),
+    Array(lambda ctx: ctx.length, UBInt8("compression_methods"))
 )
 
 Extension = Struct(
@@ -69,8 +75,9 @@ ClientHello = Struct(
     ProtocolVersion,
     Random,
     SessionID,
-    # TODO: reject hellos with cipher_suites of length 0
-    TLSPrefixedArray(EnumClass(UBInt8("cipher_suites"), CipherSuites)),
+    TLSPrefixedArray(EnumClass(UBInt8("cipher_suites"),
+                               CipherSuites),
+                     length_validator=partial(SizeAtLeast, min_size=1)),
     CompressionMethods,
     UBInt16("extensions_length"),
     Bytes("extensions_bytes", lambda ctx: ctx.extensions_length),
@@ -89,8 +96,8 @@ ServerHello = Struct(
 
 ClientCertificateType = Struct(
     "certificate_types",
-    UBInt8("length"),  # TODO: Reject packets of length 0
-    Array(lambda ctx: ctx.length, UBInt8("certificate_types")),
+    SizeAtLeast(UBInt8("length"), min_size=1),
+    Array(lambda ctx: ctx.length, UBInt8("certificate_types"))
 )
 
 SignatureAndHashAlgorithm = Struct(
@@ -101,12 +108,12 @@ SignatureAndHashAlgorithm = Struct(
 
 SupportedSignatureAlgorithms = Struct(
     "supported_signature_algorithms",
-    UBInt16("supported_signature_algorithms_length"),
-    # TODO: Reject packets of length 0
+    SizeAtLeast(UBInt16("supported_signature_algorithms_length"),
+                min_size=1),
     Array(
         lambda ctx: ctx.supported_signature_algorithms_length / 2,
         SignatureAndHashAlgorithm,
-    ),
+    )
 )
 
 DistinguishedName = Struct(
@@ -137,21 +144,24 @@ PreMasterSecret = Struct(
 
 ASN1Cert = Struct(
     "ASN1Cert",
-    UBInt32("length"),   # TODO: Reject packets with length not in 1..2^24-1
+    SizeWithin(UBInt32("length"),
+               min_size=1, max_size=2 ** 24 - 1),
     Bytes("asn1_cert", lambda ctx: ctx.length),
 )
 
 Certificate = Struct(
-    "Certificate",  # TODO: Reject packets with length > 2 ** 24 - 1
-    UBInt32("certificates_length"),
+    "Certificate",
+    SizeWithin(UBInt32("certificates_length"),
+               min_size=1, max_size=2 ** 24 - 1),
     Bytes("certificates_bytes", lambda ctx: ctx.certificates_length),
 )
 
 Handshake = Struct(
     "Handshake",
     UBInt8("msg_type"),
-    UBInt24("length"),  # TODO: Reject packets with length > 2 ** 24
+    UBInt24("length"),
     Bytes("body", lambda ctx: ctx.length),
+
 )
 
 Alert = Struct(

--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -97,7 +97,7 @@ ServerHello = Struct(
 ClientCertificateType = Struct(
     "certificate_types",
     SizeAtLeast(UBInt8("length"), min_size=1),
-    Array(lambda ctx: ctx.length, UBInt8("certificate_types"))
+    Array(lambda ctx: ctx.length, UBInt8("certificate_types")),
 )
 
 SignatureAndHashAlgorithm = Struct(
@@ -113,7 +113,7 @@ SupportedSignatureAlgorithms = Struct(
     Array(
         lambda ctx: ctx.supported_signature_algorithms_length / 2,
         SignatureAndHashAlgorithm,
-    )
+    ),
 )
 
 DistinguishedName = Struct(
@@ -161,7 +161,6 @@ Handshake = Struct(
     UBInt8("msg_type"),
     UBInt24("length"),
     Bytes("body", lambda ctx: ctx.length),
-
 )
 
 Alert = Struct(

--- a/tls/test/test_message.py
+++ b/tls/test/test_message.py
@@ -4,10 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+from construct.adapters import ValidationError
+
+import pytest
+
 from tls.hello_message import ClientHello, ProtocolVersion, ServerHello
 
 from tls.message import (
-    Certificate, CertificateRequest, ClientCertificateType, Finished,
+    ASN1Cert, Certificate, CertificateRequest, ClientCertificateType, Finished,
     Handshake, HandshakeType, HashAlgorithm, HelloRequest, PreMasterSecret,
     ServerDHParams, ServerHelloDone, SignatureAlgorithm
 )
@@ -35,6 +39,24 @@ class TestCertificateRequestParsing(object):
         b'\x00\x02'  # certificate_authorities length
         b'03'  # certificate_authorities
     )
+    certificate_types_too_short = (
+        b'\x00'  # certificate_types length
+        b''  # certificate_types
+        b''  # supported_signature_algorithms length
+        b''  # supported_signature_algorithms.hash
+        b''  # supported_signature_algorithms.signature
+        b''  # certificate_authorities length
+        b''  # certificate_authorities
+    )
+    supported_signature_algorithms_too_short = (
+        b'\x01'  # certificate_types length
+        b'\x01'  # certificate_types
+        b'\x00\x00'  # supported_signature_algorithms length
+        b''  # supported_signature_algorithms.hash
+        b''  # supported_signature_algorithms.signature
+        b''  # certificate_authorities length
+        b''  # certificate_authorities
+    )
 
     def test_parse_certificate_request(self):
         record = CertificateRequest.from_bytes(self.no_authorities_packet)
@@ -57,6 +79,51 @@ class TestCertificateRequestParsing(object):
     def test_as_bytes_with_authoritites(self):
         record = CertificateRequest.from_bytes(self.with_authorities_packet)
         assert record.as_bytes() == self.with_authorities_packet
+
+    def test_parse_certificate_types_too_short(self):
+        """
+        :py:func:`tls.message.CertificateRequest` fails to parse a
+        certificate request packet whose ``certificate_types`` is too
+        short.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            CertificateRequest.from_bytes(self.certificate_types_too_short)
+        assert exc_info.value.args == ('invalid object', 0)
+
+    def test_as_bytes_certificate_types_too_short(self):
+        """
+        :py:func:`tls.message.CertificateRequest` fails to construct a
+        certificate request packet whose ``certificate_types`` would
+        be too short.
+        """
+        record = CertificateRequest.from_bytes(self.no_authorities_packet)
+        record.certificate_types = []
+        with pytest.raises(ValidationError) as exc_info:
+            record.as_bytes()
+        assert exc_info.value.args == ('invalid object', 0)
+
+    def test_parse_supported_signature_algorithms_too_short(self):
+        """
+        :py:func:`CertificateRequest` fails to parse a certificate
+        request packet whose ``supported_signature_algorithms`` is too
+        short.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            CertificateRequest.from_bytes(
+                self.supported_signature_algorithms_too_short)
+        assert exc_info.value.args == ('invalid object', 0)
+
+    def test_as_bytes_supported_signature_algorithms_too_short(self):
+        """
+        :py:func:`CertificateRequest` fails to construct a certificate
+        request packet whose ``supported_signature_algorithms`` would
+        be too short.
+        """
+        record = CertificateRequest.from_bytes(self.no_authorities_packet)
+        record.supported_signature_algorithms = []
+        with pytest.raises(ValidationError) as exc_info:
+            record.as_bytes()
+        assert exc_info.value.args == ('invalid object', 0)
 
 
 class TestServerDHParamsparsing(object):
@@ -98,9 +165,44 @@ class TestPreMasterSecretParsing(object):
         assert record.random == r
 
 
+class TestASN1CertificateSerialization(object):
+    """
+    Tests for serializing :py:class:`tls.message.ASN1Cert`
+    """
+
+    def test_as_bytes(self):
+        """
+        :py:meth:`tls.message.ASN1Cert.as_bytes` constructs a valid
+        packet.
+        """
+        packet = (
+            b'\x00\x00\x00\x03'     # length
+            b'ABC'                  # asn1_cert
+        )
+        assert ASN1Cert(asn1_cert=b"ABC").as_bytes() == packet
+
+    def test_as_bytes_too_long(self):
+        """
+        :py:meth:`tls.message.ASN1Cert.as_bytes` fails to construct a
+        packet whose ``asn1_cert`` would be too long.
+        """
+        record = ASN1Cert(asn1_cert=b"a" * 2 ** 24)
+        with pytest.raises(ValidationError):
+            record.as_bytes()
+
+    def test_as_bytes_too_short(self):
+        """
+        :py:meth:`tls.message.ASN1Cert.as_bytes` fails to construct a
+        packet whose ``asn1_cert`` would be too short.
+        """
+        record = ASN1Cert(asn1_cert=b"")
+        with pytest.raises(ValidationError):
+            record.as_bytes()
+
+
 class TestCertificateParsing(object):
     """
-    Tests for parsing of Certificate messages.
+    Tests for parsing of :py:class:`tls.message.Certificate` messages.
     """
     packet = (
         b'\x00\x00\x00\x07'  # certificate_length
@@ -108,20 +210,79 @@ class TestCertificateParsing(object):
         b'ABC'  # certificate_list.asn1_cert
     )
 
+    certificates_too_short = (
+        b'\x00\x00\x00\x00'  # certificate_length
+        b''  # certificate_list.asn1_cert length
+        b''  # certificate_list.asn1_cert
+    )
+
+    certificates_too_long = (
+        b'\x01\x00\x00\x04'  # certificate_length
+        b'\x01\x00\x00\x00' +  # certificate_list.asn1_cert length
+        (b'a' * 0x1000000)  # certificate_list.asn1_cert
+    )
+
     def test_parse_certificate(self):
+        """
+        :py:meth:`tls.message.Certificate.from_bytes` parses a valid
+        packet.
+        """
         record = Certificate.from_bytes(self.packet)
         assert isinstance(record, Certificate)
         assert len(record.certificate_list) == 1
         assert record.certificate_list[0].asn1_cert == b'ABC'
 
     def test_as_bytes(self):
+        """
+        :py:meth:`tls.message.Certificate.as_bytes` returns a valid
+        packet.
+        """
         record = Certificate.from_bytes(self.packet)
         assert record.as_bytes() == self.packet
+
+    def test_parse_certificate_too_short(self):
+        """
+        :py:meth:`tls.message.Certificate.from_bytes` rejects a packet
+        whose ``certificate_list`` is too short.
+        """
+        with pytest.raises(ValidationError):
+            Certificate.from_bytes(self.certificates_too_short)
+
+    def test_parse_certificate_too_long(self):
+        """
+        :py:meth:`tls.message.Certificate.from_bytes` rejects a packet
+        whose ``certificate_list`` is too long.
+        """
+        with pytest.raises(ValidationError):
+            Certificate.from_bytes(self.certificates_too_long)
+
+    def test_as_bytes_too_short(self):
+        """
+        :py:meth:`tls.message.Certificate.as_bytes` fails to construct
+        a packet whose ``certificate_list`` would be too long.
+        """
+        certificate = Certificate.from_bytes(self.packet)
+        certificate.certificate_list = []
+        with pytest.raises(ValidationError):
+            certificate.as_bytes()
+
+    def test_as_bytes_too_long(self):
+        """
+        :py:meth:`tls.message.Certificate.as_bytes` fails to construct
+        a packet whose ``certificate_list`` would be too short.
+        """
+        certificate = Certificate.from_bytes(self.packet)
+        # this is kind of a cheat: the length of the packet ends up
+        # being too large, but not because there are too many
+        # ASN1Certs.  there's only one very large ASN1Cert.
+        certificate.certificate_list = [ASN1Cert(b'a' * 0x1000000)]
+        with pytest.raises(ValidationError):
+            certificate.as_bytes()
 
 
 class TestHandshakeStructParsing(object):
     """
-    Tests for parsing of Handshake structs.
+    Tests for parsing of :py:class:`tls.messages.Handshake` structs.
     """
     client_hello_packet = (
         b'\x03\x00'  # client_version

--- a/tls/test/test_record.py
+++ b/tls/test/test_record.py
@@ -4,12 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+from construct.adapters import ValidationError
+
 from construct.core import FieldError
 
 import pytest
 
 from tls.record import (
-    ContentType, TLSCiphertext, TLSCompressed, TLSPlaintext
+    ContentType, ProtocolVersion, TLSCiphertext, TLSCompressed, TLSPlaintext
 )
 
 
@@ -81,6 +83,22 @@ class TestTLSPlaintextParsing(object):
             TLSPlaintext.from_bytes(packet)
         assert str(exc_info.value) == "expected 10, found 2"
 
+    def test_parse_fragment_too_long(self):
+        """
+        :py:func:`tls.record.TLSPlaintext` fails to parsed a packet
+        containing a longer-than-allowed fragment.
+        """
+        packet = (
+            b'\x16'  # type
+            b'\x03'  # major version
+            b'\x03'  # minor version
+            b'\xff\xff' +    # big-endian length
+            (b'a' * 0xFFFF)  # fragment
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            TLSPlaintext.from_bytes(packet)
+        assert exc_info.value.args == ('invalid object', 0xFFFF)
+
     def test_as_bytes(self):
         """
         Construct a TLSPlaintext object as bytes.
@@ -94,6 +112,18 @@ class TestTLSPlaintextParsing(object):
         )
         record = TLSPlaintext.from_bytes(packet)
         assert record.as_bytes() == packet
+
+    def test_as_bytes_fragment_too_long(self):
+        """
+        :py:func:`tls.record.TLSPlaintext` fails to construct a packet
+        with a longer-than-allowed-fragment.
+        """
+        plaintext = TLSPlaintext(type=ContentType.HANDSHAKE,
+                                 version=ProtocolVersion(major=3, minor=3),
+                                 fragment=b'a' * 0xFFFF)
+        with pytest.raises(ValidationError) as exc_info:
+            plaintext.as_bytes()
+        assert exc_info.value.args == ('invalid object', 0xFFFF)
 
 
 class TestTLSCompressedParsing(object):
@@ -163,6 +193,21 @@ class TestTLSCompressedParsing(object):
             TLSCompressed.from_bytes(packet)
         assert str(exc_info.value) == "expected 10, found 2"
 
+    def test_fragment_too_long(self):
+        """
+        Reject a packet containing a longer-than-allowed fragment.
+        """
+        packet = (
+            b'\x16'  # type
+            b'\x03'  # major version
+            b'\x03'  # minor version
+            b'\xff\xff' +    # big-endian length
+            (b'a' * 0xFFFF)  # fragment
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            TLSCompressed.from_bytes(packet)
+        assert exc_info.value.args == ('invalid object', 0xFFFF)
+
 
 class TestTLSCiphertextParser(object):
     """
@@ -186,3 +231,18 @@ class TestTLSCiphertextParser(object):
         assert record.version.major == 3
         assert record.version.minor == 3
         assert record.fragment == b'0123456789'
+
+    def test_fragment_too_long(self):
+        """
+        Reject a packet containing a longer-than-allowed fragment.
+        """
+        packet = (
+            b'\x16'  # type
+            b'\x03'  # major version
+            b'\x03'  # minor version
+            b'\xff\xff' +    # big-endian length
+            (b'a' * 0xFFFF)  # fragment
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            TLSCiphertext.from_bytes(packet)
+        assert exc_info.value.args == ('invalid object', 0xFFFF)

--- a/tls/test/test_record.py
+++ b/tls/test/test_record.py
@@ -85,7 +85,7 @@ class TestTLSPlaintextParsing(object):
 
     def test_parse_fragment_too_long(self):
         """
-        :py:func:`tls.record.TLSPlaintext` fails to parsed a packet
+        :py:func:`tls.record.TLSPlaintext` fails to parse a packet
         containing a longer-than-allowed fragment.
         """
         packet = (
@@ -116,7 +116,7 @@ class TestTLSPlaintextParsing(object):
     def test_as_bytes_fragment_too_long(self):
         """
         :py:func:`tls.record.TLSPlaintext` fails to construct a packet
-        with a longer-than-allowed-fragment.
+        with a longer-than-allowed fragment.
         """
         plaintext = TLSPlaintext(type=ContentType.HANDSHAKE,
                                  version=ProtocolVersion(major=3, minor=3),
@@ -195,7 +195,8 @@ class TestTLSCompressedParsing(object):
 
     def test_fragment_too_long(self):
         """
-        Reject a packet containing a longer-than-allowed fragment.
+        :py:func:`tls.record.TLSCompressed` rejects a packet
+        containing a longer-than-allowed fragment.
         """
         packet = (
             b'\x16'  # type
@@ -234,7 +235,8 @@ class TestTLSCiphertextParser(object):
 
     def test_fragment_too_long(self):
         """
-        Reject a packet containing a longer-than-allowed fragment.
+        :py:func:`TLSCiphertext` rejects a packet containing a
+        longer-than-allowed fragment.
         """
         packet = (
             b'\x16'  # type

--- a/tls/test/test_utils.py
+++ b/tls/test/test_utils.py
@@ -13,8 +13,8 @@ from construct.core import AdaptationError, Construct, Container
 import pytest
 
 from tls.utils import (BytesAdapter, EnumClass, EnumSwitch,
-                       SizeAtLeast, SizeAtMost, SizeWithin,
-                       PrefixedBytes, TLSPrefixedArray, UBInt24,
+                       PrefixedBytes, SizeAtLeast, SizeAtMost,
+                       SizeWithin, TLSPrefixedArray, UBInt24,
                        _UBInt24)
 
 
@@ -238,14 +238,14 @@ class Equals5(Validator):
         return obj == 5
 
 
-class TLSPrefixedArrayWithLengthValidator(object):
+class TestTLSPrefixedArrayWithLengthValidator(object):
     """
     Tests for :py:class:`tls.utils.TLSPrefixedArray` with a
     ``length_validator``.
     """
 
     @pytest.fixture
-    def TLSUBInt8Array(self):
+    def TLSUBInt8Array(self):  # noqa
         """
         A :py:class:`tls.utils.TLSPrefixedArray` specialized on
         :py:func:`construct.macros.UBInt8`
@@ -263,10 +263,10 @@ class TLSPrefixedArrayWithLengthValidator(object):
                                 length_validator=Equals5)
 
     @pytest.mark.parametrize('invalid', [
-        [1, 2, 3, 4],
+        [1, 2, 3, 4],  # noqa
         [1, 2, 3, 4, 5, 6],
     ])
-    def test_build_invalid(self, TLSUBInt8Length5Array, invalid):  # noqa
+    def test_build_invalid(self, TLSUBInt8Length5Array, invalid):
         """
         :py:class:`tls.utils.TLSPrefixedArray` raises a
         :py:exc:`construct.adapters.ValidationError` when encoding a
@@ -276,10 +276,10 @@ class TLSPrefixedArrayWithLengthValidator(object):
             TLSUBInt8Length5Array.build(invalid)
 
     @pytest.mark.parametrize('invalid', [
-        b'\x00\x04' + b'\x01\x02\x03\x04',
+        b'\x00\x04' + b'\x01\x02\x03\x04',  # noqa
         b'\x00\x06' + b'\x01\x02\x03\x04\x05\x06',
     ])
-    def test_parse_invalid(self, TLSUBInt8Length5Array, invalid):  # noqa
+    def test_parse_invalid(self, TLSUBInt8Length5Array, invalid):
         """
         :py:class:`tls.utils.TLSPrefixedArray` raises a
         :py:exc:`construct.adapters.ValidationError` when decoding an
@@ -288,15 +288,15 @@ class TLSPrefixedArrayWithLengthValidator(object):
         with pytest.raises(ValidationError):
             TLSUBInt8Length5Array.parse(invalid)
 
-    def test_parse_valid(self, TLSUBInt8Length5Array, TLSUBInt8Array):
+    def test_parse_valid(self, TLSUBInt8Length5Array, TLSUBInt8Array):  # noqa
         """
         :py:class:`tls.utils.TLSPrefixedArray` decodes an array that
         passes validation.
         """
-        valid = b'\x00\x05' + '\x01\x02\x03\x04\x05'
+        valid = b'\x00\x05' + b'\x01\x02\x03\x04\x05'
         assert TLSUBInt8Array.parse(valid) == TLSUBInt8Array.parse(valid)
 
-    def test_build_valid(self, TLSUBInt8Length5Array, TLSUBInt8Array):
+    def test_build_valid(self, TLSUBInt8Length5Array, TLSUBInt8Array):   # noqa
         """
         :py:class:`tls.utils.TLSPrefixedArray` encodes an array that
         passes validation.

--- a/tls/utils.py
+++ b/tls/utils.py
@@ -163,3 +163,90 @@ def EnumSwitch(type_field, type_enum, value_field, value_choices):  # noqa
             construct.Switch(value_field,
                              operator.attrgetter(type_field.name),
                              value_choices))
+
+
+class SizeAtLeast(construct.Validator):
+    """
+    A :py:class:`construct.adapter.Validator` that validates a
+    sequence size is greater than or equal to some minimum.
+
+    >>> from tls.utils import SizeAtLeast, PrefixedBytes
+    >>> SizeAtLeast(PrefixedBytes(None), min_size=2).parse(b'\x01a')
+    Traceback (most recent call last):
+        ...
+    construct.core.ValidationError: ('invalid object', b'\x01a')
+
+    :param subcon: the construct to validate.
+    :type subcon: :py:class:`construct.core.Construct`
+
+    :param min_size: the (inclusive) minimum allowable size for the
+        validated sequence.
+    :type min_size: :py:class:`int`
+    """
+    def __init__(self, subconn, min_size):
+        super(SizeAtLeast, self).__init__(subconn)
+        self.min_size = min_size
+
+    def _validate(self, obj, context):
+        return self.min_size <= obj
+
+
+class SizeAtMost(construct.Validator):
+    """
+    A :py:class:`construct.adapter.Validator` that validates a
+    sequence size is less than or equal to some maximum.
+
+    >>> from tls.utils import SizeAtMost, PrefixedBytes
+    >>> SizeAtMost(PrefixedBytes(None), max_size=1).parse(b'\x02aa')
+    Traceback (most recent call last):
+        ...
+    construct.core.ValidationError: ('invalid object', b'\x02aa')
+
+    :param subcon: the construct to validate.
+    :type subcon: :py:class:`construct.core.Construct`
+
+    :param max_size: the (inclusive) maximum allowable size for the
+        validated sequence.
+    :type max_size: :py:class:`int`
+    """
+
+    def __init__(self, subconn, max_size):
+        super(SizeAtMost, self).__init__(subconn)
+        self.max_size = max_size
+
+    def _validate(self, obj, context):
+        return obj <= self.max_size
+
+
+class SizeWithin(construct.Validator):
+    """
+    A :py:class:`construct.adapter.Validator` that validates a
+    sequence's size is within some bounds.  The bounds are
+    inclusive.
+
+    >>> from tls.utils import SizeWithin, PrefixedBytes
+    >>> SizeWithin(PrefixedBytes(None),
+    ...              min_size=2, max_size=2).parse(b'\x01a')
+    Traceback (most recent call last):
+        ...
+    construct.core.ValidationError: ('invalid object', b'\x01a')
+
+    :param subcon: the construct to validate.
+    :type subcon: :py:class:`construct.core.Construct`
+
+    :param min_size: the (inclusive) minimum allowable size for the
+        validated sequence.
+    :type min_size: :py:class:`int`
+
+    :param max_size: the (inclusive) maximum allowable size for the
+        validated sequence.
+    :type max_size: :py:class:`int`
+    """
+
+    def __init__(self, subconn, min_size, max_size):
+        super(SizeWithin, self).__init__(subconn)
+        self.min_size = min_size
+        self.max_size = max_size
+
+    def _validate(self, obj, context):
+        return self.min_size <= obj <= self.max_size

--- a/tls/utils.py
+++ b/tls/utils.py
@@ -79,7 +79,7 @@ def TLSPrefixedArray(subconn, length_name="length", length_validator=None):  # n
     reading a leading 16 bit length.
 
     :param subconn: The construct this array contains.
-    :type subconn: `construct.Construct`
+    :type subconn: ``construct.Construct``
 
     :param length_name: (optional) The attribute name under which the
         :class:`construct.macros.UBInt16` representing this array's
@@ -93,7 +93,7 @@ def TLSPrefixedArray(subconn, length_name="length", length_validator=None):  # n
         construct of the array as its only argument and returns a
         :py:class:`construct.adapters.Validator`
 
-        ..  _TLS vector type:
+     ..  _TLS vector type:
         https://tools.ietf.org/html/rfc5246#section-4.3
     """
     length_field = construct.UBInt16(length_name)
@@ -180,11 +180,13 @@ class SizeAtLeast(construct.Validator):
     A :py:class:`construct.adapter.Validator` that validates a
     sequence size is greater than or equal to some minimum.
 
+    >>> from construct import UBInt8
     >>> from tls.utils import SizeAtLeast, PrefixedBytes
-    >>> SizeAtLeast(PrefixedBytes(None), min_size=2).parse(b'\x01a')
+    >>> PrefixedBytes(None, SizeAtLeast(UBInt8("length"),
+    ...                     min_size=2)).parse(b'\x01a')
     Traceback (most recent call last):
         ...
-    construct.core.ValidationError: ('invalid object', b'\x01a')
+    construct.core.ValidationError: ('invalid object', b'a')
 
     :param subcon: the construct to validate.
     :type subcon: :py:class:`construct.core.Construct`
@@ -207,7 +209,8 @@ class SizeAtMost(construct.Validator):
     sequence size is less than or equal to some maximum.
 
     >>> from tls.utils import SizeAtMost, PrefixedBytes
-    >>> SizeAtMost(PrefixedBytes(None), max_size=1).parse(b'\x02aa')
+    >>> PrefixedBytes(None, SizeAtMost(UBInt8("length"),
+    ...                     max_size=1)).parse(b'\x02aa')
     Traceback (most recent call last):
         ...
     construct.core.ValidationError: ('invalid object', b'\x02aa')
@@ -235,8 +238,8 @@ class SizeWithin(construct.Validator):
     inclusive.
 
     >>> from tls.utils import SizeWithin, PrefixedBytes
-    >>> SizeWithin(PrefixedBytes(None),
-    ...              min_size=2, max_size=2).parse(b'\x01a')
+    >>> PrefixedBytes(None, SizeWithin(UBInt8("length"),
+    ...                     min_size=2, max_size=2)).parse(b'\x01a')
     Traceback (most recent call last):
         ...
     construct.core.ValidationError: ('invalid object', b'\x01a')

--- a/tls/utils.py
+++ b/tls/utils.py
@@ -71,7 +71,7 @@ def PrefixedBytes(name, length_field=construct.UBInt8("length")):  # noqa
     )
 
 
-def TLSPrefixedArray(subconn, length_name="length"):  # noqa
+def TLSPrefixedArray(subconn, length_name="length", length_validator=None):  # noqa
     """
     The `TLS vector type`_.  It specializes on another
     :py:class:`construct.Construct` and then encodes or decodes an
@@ -81,17 +81,27 @@ def TLSPrefixedArray(subconn, length_name="length"):  # noqa
     :param subconn: The construct this array contains.
     :type subconn: `construct.Construct`
 
-    :param length_field: (optional) The attribute name under which the
+    :param length_name: (optional) The attribute name under which the
         :class:`construct.macros.UBInt16` representing this array's
         length will be accessible.  You do not need to provide this
         when encoding a python sequence!
-    :type length_field: :py:class:`str`
+    :type length_name: :py:class:`str`
 
-    ..  _TLS vector type: https://tools.ietf.org/html/rfc5246#section-4.3
+    :param length_validator: (optional) A callable that validates the
+        array's length construct.
+    :type length_validator: a callable that accepts the length
+        construct of the array as its only argument and returns a
+        :py:class:`construct.adapters.Validator`
+
+        ..  _TLS vector type:
+        https://tools.ietf.org/html/rfc5246#section-4.3
     """
-    return construct.PrefixedArray(
-        subconn,
-        length_field=construct.UBInt16(length_name))
+    length_field = construct.UBInt16(length_name)
+
+    if length_validator is not None:
+        length_field = length_validator(length_field)
+
+    return construct.PrefixedArray(subconn, length_field=length_field)
 
 
 def EnumClass(type_field, type_enum):  # noqa


### PR DESCRIPTION
This introduces `SizeAtMost`, `SizeAtLeast`, and `SizeWithin` validators.  They validate numeric fields.

The idea is that the the length field of any given TLS message would be wrapped in one of these validators.  There's a little song and dance to make this work with `TLSPrefixedArray`.

A good thing about this approach is that an over-long message won't be parsed, as it will be rejected on the basis of its prefixed length (though the tests do use very long messages as a defensive measure.  This seems to have slowed them down and is worth discussing!).

A bad thing about this approach is that the `ValidationErrors` include only the lengths that are wrong, not the contents.  This may make debugging harder.  I think the right solution will still validate actual size of the length fields, not the contents of what they measure, but provide more context about which construct the error occurred within.