### PR TITLE
Introduce Opaque construct to aid parsing extensions.

### DIFF
--- a/tls/_common/_constructs.py
+++ b/tls/_common/_constructs.py
@@ -108,6 +108,29 @@ def TLSPrefixedArray(name, subcon, length_validator=None):  # noqa
     )
 
 
+def Opaque(subcon):  # noqa
+    """
+    An `opaque`_ sequence of bytes.  Such a sequence consists of a 16
+    bit integer followed that many bytes.  It behaves like
+    :py:class:`TLSPrefixedArray` except that it returns a single
+    construct instance and not a sequence of them.
+
+    :param subcon: The construct to wrap.
+    :type subcon: :py:class:`construct.Construct`
+
+    .. _opaque:
+        https://tools.ietf.org/html/rfc5246#section-4.3
+
+    """
+
+    length_field = construct.UBInt16(subcon.name + "_opaque_length")
+    return construct.TunnelAdapter(
+        PrefixedBytes(subcon.name,
+                      length_field),
+        subcon,
+    )
+
+
 def EnumClass(type_field, type_enum):  # noqa
     """
     Maps the members of an :py:class:`enum.Enum` to a single kind of

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -12,9 +12,11 @@ from construct.core import AdaptationError, Construct, Container
 
 import pytest
 
-from tls._common._constructs import (BytesAdapter, EnumClass, EnumSwitch,
-                                     PrefixedBytes, SizeAtLeast, SizeAtMost,
-                                     SizeWithin, TLSPrefixedArray, UBInt24,
+from tls._common._constructs import (BytesAdapter, EnumClass,
+                                     EnumSwitch, Opaque,
+                                     PrefixedBytes, SizeAtLeast,
+                                     SizeAtMost, SizeWithin,
+                                     TLSPrefixedArray, UBInt24,
                                      _UBInt24)
 
 
@@ -303,6 +305,34 @@ class TestTLSPrefixedArrayWithLengthValidator(object):
         """
         valid = [1, 2, 3, 4, 5]
         assert TLSUBInt8Array.build(valid) == TLSUBInt8Array.build(valid)
+
+
+class TestOpaque(object):
+    """
+    Tests for :py:func:`tls._common._constructs.Opaque`.
+    """
+
+    @pytest.fixture
+    def opaque_ubint16(self):
+        """
+        A :py:func:`tls._common._constructs.Opaque` specialized on
+        :py:func:`construct.UBInt16`.
+        """
+        return Opaque(UBInt16("datum"))
+
+    def test_parse(self, opaque_ubint16):
+        """
+        :py:func:`tls._common._constructs.Opaque` decodes an opaque 16
+        bit integer.
+        """
+        assert opaque_ubint16.parse(b'\x00\x02\x02\x80') == 640
+
+    def test_build(self, opaque_ubint16):
+        """
+        :py:func:`tls._common._constructs.Opaque` encodes a 16 bit
+        integer as an opaque sequence of bytes.
+        """
+        assert opaque_ubint16.build(640) == b'\x00\x02\x02\x80'
 
 
 class IntegerEnum(enum.Enum):


### PR DESCRIPTION
RFC 5246 defines the extension type as:

```
      struct {
          ExtensionType extension_type;
          opaque extension_data<0..2^16-1>;
      } Extension;
```
`opaque` declarations with lengths greater than one are represented exactly the same as TLS vectors.  That means on the wire, the extension's `data` field begins with a 16-bit integer that describes its length!

Consider the following `signature_algorithms` extension blob extracted from a Firefox-initiated Client Hello to google.com:
`'\x00\r\x00\x16\x00\x14\x04\x01\x05\x01\x06\x01\x02\x01\x04\x03\x05\x03\x06\x03\x02\x03\x04\x02\x02\x02'`

`\x00\r`: the extension type (13, `SIGNATURE_ALGORITHMS`)
`\x00\x16`: the length of the data field (22) 
`\x00\x14\x04\x01...`: the actual data

We can parse this by taking @ashfall's [work-in-progress extension parsing](https://github.com/ashfall/tls/blob/ext-parsing-1/tls/_constructs.py#L99) and wrapping each extension type in `Opaque`:

```python 
Extension = Struct(
    "extension",
    *EnumSwitch(
        type_field=UBInt16("type"),
        type_enum=enums.ExtensionType,
        value_field="data",
        value_choices={
            enums.ExtensionType.SERVER_NAME: Opaque(ServerName),
            enums.ExtensionType.SIGNATURE_ALGORITHMS: Opaque(SupportedSignatureAlgorithms),
        })
)
```

```
>>> Extension.parse('\x00\r\x00\x16\x00\x14\x04\x01\x05\x01\x06\x01\x02\x01\x04\x03\x05\x03\x06\x03\x02\x03\x04\x02\x02\x02')
Container({'data': [Container({'hash': <HashAlgorithm.SHA256: 4>, 'signature': <SignatureAlgorithm.RSA: 1>}), Container({'hash': <HashAlgorithm.SHA384: 5>, 'signature': <SignatureAlgorithm.RSA: 1>}), Container({'hash': <HashAlgorithm.SHA512: 6>, 'signature': <SignatureAlgorithm.RSA: 1>}), Container({'hash': <HashAlgorithm.SHA1: 2>, 'signature': <SignatureAlgorithm.RSA: 1>}), Container({'hash': <HashAlgorithm.SHA256: 4>, 'signature': <SignatureAlgorithm.ECDSA: 3>}), Container({'hash': <HashAlgorithm.SHA384: 5>, 'signature': <SignatureAlgorithm.ECDSA: 3>}), Container({'hash': <HashAlgorithm.SHA512: 6>, 'signature': <SignatureAlgorithm.ECDSA: 3>}), Container({'hash': <HashAlgorithm.SHA1: 2>, 'signature': <SignatureAlgorithm.ECDSA: 3>}), Container({'hash': <HashAlgorithm.SHA256: 4>, 'signature': <SignatureAlgorithm.DSA: 2>}), Container({'hash': <HashAlgorithm.SHA1: 2>, 'signature': <SignatureAlgorithm.DSA: 2>})], 'type': <ExtensionType.SIGNATURE_ALGORITHMS: 13>})
```