### PR TITLE
Add an optional length_field_size for use with TLS vectors that use a…

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,3 +21,4 @@ versa
 prf
 py
 hmac
+UBInt

--- a/tls/_common/_constructs.py
+++ b/tls/_common/_constructs.py
@@ -73,7 +73,8 @@ def PrefixedBytes(name, length_field=construct.UBInt8("length")):  # noqa
     )
 
 
-def TLSPrefixedArray(name, subcon, length_validator=None, length_field_size=construct.UBInt16):  # noqa
+def TLSPrefixedArray(name, subcon, length_validator=None,
+                     length_field_size=construct.UBInt16):
     """
     The `TLS vector type`_.  It specializes on another
     :py:class:`construct.Construct` and then encodes or decodes an

--- a/tls/_common/_constructs.py
+++ b/tls/_common/_constructs.py
@@ -73,7 +73,7 @@ def PrefixedBytes(name, length_field=construct.UBInt8("length")):  # noqa
     )
 
 
-def TLSPrefixedArray(name, subcon, length_validator=None,
+def TLSPrefixedArray(name, subcon, length_validator=None,  # noqa
                      length_field_size=construct.UBInt16):
     """
     The `TLS vector type`_.  It specializes on another

--- a/tls/_common/_constructs.py
+++ b/tls/_common/_constructs.py
@@ -73,7 +73,7 @@ def PrefixedBytes(name, length_field=construct.UBInt8("length")):  # noqa
     )
 
 
-def TLSPrefixedArray(name, subcon, length_validator=None):  # noqa
+def TLSPrefixedArray(name, subcon, length_validator=None, length_field_size=construct.UBInt16):  # noqa
     """
     The `TLS vector type`_.  It specializes on another
     :py:class:`construct.Construct` and then encodes or decodes an
@@ -93,12 +93,17 @@ def TLSPrefixedArray(name, subcon, length_validator=None):  # noqa
         construct of the array as its only argument and returns a
         :py:class:`construct.adapters.Validator`
 
+    :param length_field_size: (optional) The prefixed length field for
+        representing the array length. Defaults to
+        :py:func:`construct.macros.UBInt16`.
+    :type length_field_size: a :py:class:`construct.core.FormatField`
+
     ..  _TLS vector type:
         https://tools.ietf.org/html/rfc5246#section-4.3
     """
     # This needs a name so that PrefixedBytes' length function can
     # retrieve it
-    length_field = construct.UBInt16(name + "_length")
+    length_field = length_field_size(name + "_length")
 
     if length_validator is not None:
         length_field = length_validator(length_field)

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -383,8 +383,9 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         """
         A :py:meth:`tls._common._constructs.TLSPrefixedArray` decodes a
         length-prefixed binary sequence encoded by a
-        :py:meth:`tls._common._constructs.TLSPrefixedArray` specialized on the
-        same construct and vice versa.
+        :py:meth:`tls._common._constructs.TLSPrefixedArray` with a custom
+        ``length_field_value`` of :py:class`UBInt24` overriding the default
+        `UBInt16` specialized on the same construct and vice versa.
         """
 
         parsed = tls_array.parse(uint8_encoded)

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -352,8 +352,8 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
     def tls_array(self):
         """
         A :py:func:`tls._common._constructs.TLSPrefixedArray` of
-        :py:func:`construct.macros.UBInt8` where the legth prefix for the array
-        size is specified with a py:class`UBInt24` value.
+        :py:func:`construct.macros.UBInt8` where the length prefix for the array
+        size is specified with a :py:class`UBInt24` value.
         """
         return TLSPrefixedArray("digits", UBInt8("digit"),
                                 length_field_size=UBInt24)
@@ -362,9 +362,9 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         """
         A :py:meth:`tls._common._constructs.TLSPrefixedArray` specialized on a
         given :py:func:`construct.Construct` encodes a sequence of objects as a
-        24-bit length (since ``TLSPrefixedArray.legth_field_size`` has been set
-        to ``UBInt24``, overriding the default ``UBInt16``) followed by each
-        object as encoded by that construct.
+        24-bit length (since ``TLSPrefixedArray.length_field_size`` has been
+        set to :py:class`UBInt24`, overriding the default :py:class`UBInt16`)
+        followed by each object as encoded by that construct.
         """
         assert tls_array.build(ints) == uint8_encoded
 
@@ -373,9 +373,9 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         A :py:meth:`tls._common._constructs.TLSPrefixedArray` specialized on a
         given :py:func:`construct.Construct` decodes a binary sequence,
         prefixed by its 24-bit length (since
-        ``TLSPrefixedArray.legth_field_size`` has been set to ``UBInt24``,
-        overriding the default ``UBInt16``), as a :py:class:`list` of objects
-        decoded by that construct.
+        ``TLSPrefixedArray.length_field_size`` has been set to
+        :py:class`UBInt24`, overriding the default :py:class`UBInt16`), as a
+        :py:class:`list` of objects decoded by that construct.
         """
         assert tls_array.parse(uint8_encoded) == ints
 
@@ -385,7 +385,7 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         length-prefixed binary sequence encoded by a
         :py:meth:`tls._common._constructs.TLSPrefixedArray` with a custom
         ``length_field_value`` of :py:class`UBInt24` overriding the default
-        `UBInt16` specialized on the same construct and vice versa.
+        :py:class`UBInt16` specialized on the same construct and vice versa.
         """
 
         parsed = tls_array.parse(uint8_encoded)

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -352,8 +352,8 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
     def tls_array(self):
         """
         A :py:func:`tls._common._constructs.TLSPrefixedArray` of
-        :py:func:`construct.macros.UBInt8` where the length prefix for the array
-        size is specified with a :py:class`UBInt24` value.
+        :py:func:`construct.macros.UBInt8` where the length prefix for the
+        array size is specified with a :py:class`UBInt24` value.
         """
         return TLSPrefixedArray("digits", UBInt8("digit"),
                                 length_field_size=UBInt24)

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -295,7 +295,7 @@ class TestPrefixedBytesWithOverriddenLength(object):
 class TestTLSPrefixedArrayWithDefaultLengthFieldSize(object):
     """
     Tests for :py:func:`tls._common._constructs.TLSPrefixedArray` where the
-    length_field is specified using a UBInt16 value.
+    ``length_field_size`` defaults to :py:class`UBInt16`.
     """
 
     @pytest.fixture
@@ -345,14 +345,15 @@ class TestTLSPrefixedArrayWithDefaultLengthFieldSize(object):
 class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
     """
     Tests for :py:func:`tls._common._constructs.TLSPrefixedArray` where the
-    length_field is supplied by the user.
+    ``length_field_size`` is supplied by the user.
     """
 
     @pytest.fixture
     def tls_array(self):
         """
         A :py:func:`tls._common._constructs.TLSPrefixedArray` of
-        :py:func:`construct.macros.UBInt8`.
+        :py:func:`construct.macros.UBInt8` where the legth prefix for the array
+        size is specified with a py:class`UBInt24` value.
         """
         return TLSPrefixedArray("digits", UBInt8("digit"),
                                 length_field_size=UBInt24)
@@ -361,7 +362,9 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         """
         A :py:meth:`tls._common._constructs.TLSPrefixedArray` specialized on a
         given :py:func:`construct.Construct` encodes a sequence of objects as a
-        24-bit length followed by each object as encoded by that construct.
+        24-bit length (since ``TLSPrefixedArray.legth_field_size`` has been set
+        to ``UBInt24``, overriding the default ``UBInt16``) followed by each
+        object as encoded by that construct.
         """
         assert tls_array.build(ints) == uint8_encoded
 
@@ -369,8 +372,10 @@ class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
         """
         A :py:meth:`tls._common._constructs.TLSPrefixedArray` specialized on a
         given :py:func:`construct.Construct` decodes a binary sequence,
-        prefixed by its 24-bit length, as a :py:class:`list` of objects decoded
-        by that construct.
+        prefixed by its 24-bit length (since
+        ``TLSPrefixedArray.legth_field_size`` has been set to ``UBInt24``,
+        overriding the default ``UBInt16``), as a :py:class:`list` of objects
+        decoded by that construct.
         """
         assert tls_array.parse(uint8_encoded) == ints
 


### PR DESCRIPTION
… length prefix that's not UBInt16 format.

I need this for https://github.com/pyca/tls/issues/109, `Certificate` uses `UBInt32` to represent the length of the `certificate_list`.