### PR TITLE
update LICENSE and LICENSE.BSD to refer to the PyCA TLS project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
 This software is made available under the terms of *either* of the licenses
-found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made
+found in LICENSE.APACHE or LICENSE.BSD. Contributions to PyCA TLS are made
 under the terms of *both* these licenses.

--- a/LICENSE.BSD
+++ b/LICENSE.BSD
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
        notice, this list of conditions and the following disclaimer in the
        documentation and/or other materials provided with the distribution.
 
-    3. Neither the name of PyCA Cryptography nor the names of its contributors
+    3. Neither the name of PyCA TLS nor the names of its contributors
        may be used to endorse or promote products derived from this software
        without specific prior written permission.
 


### PR DESCRIPTION
All good licenses should refer to their containing projects. :)